### PR TITLE
csaf field improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,25 +74,25 @@ a dict with three keys:
 | "no_line_separators"  | "Every line must end with either a carriage return and line feed characters or just a line feed character"                                                             |
 | "signed_format_issue" | "Signed security.txt must start with the header '-----BEGIN PGP SIGNED MESSAGE-----'. "                                                                                |
 | "data_after_sig"      | "Signed security.txt must not contain data after the signature."                                                                                                       |
-| "no_csaf_file"        | "All CSAF field in the security.txt must point to a provider-metadata.json file"                                                                                       |
+| "no_csaf_file"        | "All CSAF fields must point to a provider-metadata.json file."                                                                                                         |
 
 
 ### Possible recommendations
 
-| code                       | message                                                                                |
-|----------------------------|----------------------------------------------------------------------------------------|
-| "long_expiry"              | "Date and time in 'Expires' field should be less than a year into the future."         |
-| "no_encryption"            | "'Encryption' field should be present when 'Contact' field contains an email address." |
-| "not_signed"<sup>[1]</sup> | "security.txt should be digitally signed."                                             |
-| "no_canonical"             | "'Canonical' field should be present in a signed file."                                |
-| "no_csaf"                  | "'CSAF' field should appear at least once"                                             |
+| code                       | message                                                                                        |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| "long_expiry"              | "Date and time in 'Expires' field should be less than a year into the future."                 |
+| "no_encryption"            | "'Encryption' field should be present when 'Contact' field contains an email address."         |
+| "not_signed"<sup>[1]</sup> | "security.txt should be digitally signed."                                                     |
+| "no_canonical"             | "'Canonical' field should be present in a signed file."                                        |
+| "multiple_csaf_fields"     | "It is allowed to have more than one CSAF field, however this should be removed if possible."  |
 
 ### Possible notifications
 
 | code                          | message                                                                                                                                                                     |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | "unknown_field"<sup>[2]</sup> | "Security.txt contains an unknown field. Field {unknown_field} is either a custom field which may not be widely supported, or there is a typo in a standardised field name. |
-| "multiple_csaf_fields"        | "It is allowed to have more than one CSAF field, however this should be removed if possible."                                                                               |
+
 
 ---
 

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -289,21 +289,16 @@ class Parser:
                 "feed character",
             )
 
-        if "csaf" not in self._values:
-            self._add_recommendation(
-                "no_csaf", "'CSAF' field should appear at least once"
-            )
-        else:
+        if "csaf" in self._values:
             if not all(
                 v.endswith("provider-metadata.json") for v in self._values["csaf"]
             ):
                 self._add_error(
                     "no_csaf_file",
-                    "All CSAF field in the security.txt must point "
-                    "to a provider-metadata.json file",
+                    "All CSAF fields must point to a provider-metadata.json file.",
                 )
             if len(self._values["csaf"]) > 1:
-                self._add_notification(
+                self._add_recommendation(
                     "multiple_csaf_fields",
                     "It is allowed to have more than one csaf field, "
                     "however this should be removed if possible.",

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -183,16 +183,6 @@ class SecTxtTestCase(TestCase):
             len([1 for r in p._errors if r["code"] == "no_line_separators"]), 1
         )
 
-    def test_csaf_optional(self):
-        content = _signed_example.replace(
-            "CSAF: https://example.com/.well-known/csaf/provider-metadata.json", ""
-        )
-        p = Parser(content)
-        self.assertTrue(p.is_valid())
-        self.assertEqual(
-            len([1 for r in p._recommendations if r["code"] == "no_csaf"]), 1
-        )
-
     def test_csaf_https_uri(self):
         content = _signed_example.replace(
             "CSAF: https://example.com/.well-known/csaf/provider-metadata.json",
@@ -220,7 +210,7 @@ class SecTxtTestCase(TestCase):
         p = Parser(content)
         self.assertTrue(p.is_valid())
         self.assertEqual(
-            len([1 for r in p._notifications if r["code"] == "multiple_csaf_fields"]), 1
+            len([1 for r in p._recommendations if r["code"] == "multiple_csaf_fields"]), 1
         )
 
 


### PR DESCRIPTION
As noted in issue #47 there were some improvements remarks

- The CSAF field is not optional (like "Acknowledgments" and "Hiring") so the recommendation is removed. The errors remain, if the field is listed with an issue it will throw an error. 
- The "multiple_csaf_fields" has been moved from a notification to a recommendation.
- The "no_csaf_file" text has been updated to be more clear.
